### PR TITLE
replaced float with flex, adjusted padding on reactions and container

### DIFF
--- a/spideymoji.css
+++ b/spideymoji.css
@@ -39,8 +39,7 @@
     opacity: 0;
     background: #fff;
     box-sizing: border-box;
-    width: 342px;
-    padding: 5px 3px;
+    width: auto;
     position: absolute;
     top: -50px;
     left: 0;
@@ -54,18 +53,25 @@
 }
 
 .spideymoji.hover .spidey-reactions-container {
-    display: block;
+    display: flex;
     opacity: 1;
 }
 
 .spidey-reaction {
     min-height: 40px;
     min-width: 40px;
-    padding: 0 4px;
-    float: left;
+    padding: 5px 4px;
     position: relative;
     border-radius: 50%;
     cursor: pointer;
+}
+
+.spidey-reaction:first-child {
+    padding-left: 7px;
+}
+
+.spidey-reaction:last-child {
+    padding-right: 7px;
 }
 
 .spidey-img {


### PR DESCRIPTION
- Changed fixed width of container to auto after removing float property from children
- Changed container display property to flex so reactions would "float" adjacent to one another
- Removed padding from reactions container to allow content to fill entire container. This also resolved the issue with reactions "bouncing" repeatedly (#5) because there is no longer whitespace below the reaction when it floats up on hover.
- Added increased padding around first and last reaction to compensate for left/right padding removed from container